### PR TITLE
chore: rename package in changelog

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-linglong-store (1.6.7-1) unstable; urgency=medium
+linyaps-web-store-installer (1.6.7-1) unstable; urgency=medium
 
   * release 1.6.7-1.
 


### PR DESCRIPTION
The package name in `debian/changelog` was incorrect. It was previously named `linglong-store` but the correct name is `linyaps-web-store- installer`. This commit corrects the package name to align with the project's actual naming. This ensures accurate tracking of package versions and updates within the Debian packaging system.

feat: 在更新日志中重命名软件包

`debian/changelog` 中的软件包名称不正确。之前名为 `linglong-store`，但 正确的名称是 `linyaps-web-store-installer`。此提交更正了软件包名称，以与 项目的实际命名保持一致。这确保了 Debian 打包系统中软件包版本和更新的准确
跟踪。